### PR TITLE
check for blob existence after writes

### DIFF
--- a/pkg/casutil/casutil.go
+++ b/pkg/casutil/casutil.go
@@ -120,3 +120,22 @@ func GetProto(
 
 	return nil
 }
+
+func FindMissingBlobs(
+	ctx context.Context,
+	casClient remote_pb.ContentAddressableStorageClient,
+	digests []*remote_pb.Digest,
+	instanceName string,
+) ([]*remote_pb.Digest, error) {
+	request := remote_pb.FindMissingBlobsRequest{
+		BlobDigests:  digests,
+		InstanceName: instanceName,
+	}
+
+	response, err := casClient.FindMissingBlobs(ctx, &request)
+	if err != nil {
+		return nil, err
+	}
+
+	return response.MissingBlobDigests, nil
+}


### PR DESCRIPTION
Check for existence of just-written blobs to ensure that the server has the blob. (Further work could read the blob back from the server to verify its contents.)