### PR TITLE
casload: use bytestream api for large blobs

### DIFF
--- a/cmd/casload/main.go
+++ b/cmd/casload/main.go
@@ -36,7 +36,7 @@ func main() {
 	verboseOpt := pflag.CountP("verbose", "v", "increase logging verbosity")
 	useJsonLoggingOpt := pflag.Bool("log-json", false, "log using JSON")
 	allowInsecureAuthOpt := pflag.Bool("allow-insecure-auth", false, "allow credentials to be passed unencrypted (i.e., no TLS)")
-	streamChunkSize := pflag.Int64("chunk-size", 512*1024, "number of bytes per bytestream chunk")
+	writeChunkSize := pflag.Int64("write-chunk-size", 512*1024, "number of bytes per bytestream chunk")
 	maxBatchBlobSize := pflag.Int64("max-batch-blob-size", 512*1024, "maximum number of bytes per blob permitted to use BatchUpdateBlobs")
 
 	pflag.Parse()
@@ -97,7 +97,7 @@ func main() {
 		BytestreamClient: cs.bytestreamClient,
 		Ctx:              ctx,
 		KnownDigests:     make(map[string]bool),
-		StreamChunkSize:  *streamChunkSize,
+		WriteChunkSize:   *writeChunkSize,
 		MaxBatchBlobSize: *maxBatchBlobSize,
 	}
 

--- a/cmd/casload/main.go
+++ b/cmd/casload/main.go
@@ -36,6 +36,8 @@ func main() {
 	verboseOpt := pflag.CountP("verbose", "v", "increase logging verbosity")
 	useJsonLoggingOpt := pflag.Bool("log-json", false, "log using JSON")
 	allowInsecureAuthOpt := pflag.Bool("allow-insecure-auth", false, "allow credentials to be passed unencrypted (i.e., no TLS)")
+	streamChunkSize := pflag.Int64("chunk-size", 512*1024, "number of bytes per bytestream chunk")
+	maxBatchBlobSize := pflag.Int64("max-batch-blob-size", 512*1024, "maximum number of bytes per blob permitted to use BatchUpdateBlobs")
 
 	pflag.Parse()
 
@@ -95,6 +97,8 @@ func main() {
 		BytestreamClient: cs.bytestreamClient,
 		Ctx:              ctx,
 		KnownDigests:     make(map[string]bool),
+		StreamChunkSize:  *streamChunkSize,
+		MaxBatchBlobSize: *maxBatchBlobSize,
 	}
 
 	for _, action := range actions {

--- a/go.mod
+++ b/go.mod
@@ -10,4 +10,5 @@ require (
 	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013
 	google.golang.org/grpc v1.33.2
 	google.golang.org/protobuf v1.25.0
+	github.com/google/uuid v1.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,8 @@ github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.2.0 h1:qJYtXnJRWmpe7m/3XlyhrsLrEURqHRM2kxzoxXqyUDs=
+github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=

--- a/pkg/casutil/casutil.go
+++ b/pkg/casutil/casutil.go
@@ -264,6 +264,9 @@ func GetBytesStream(
 
 	for {
 		response, err := readClient.Recv()
+		if err == io.EOF {
+			break
+		}
 		if err != nil {
 			return nil, fmt.Errorf("failed to read digest: %s", err)
 		}

--- a/pkg/load/action.go
+++ b/pkg/load/action.go
@@ -32,6 +32,8 @@ type ActionContext struct {
 	CasClient        remote_pb.ContentAddressableStorageClient
 	BytestreamClient bytestream_pb.ByteStreamClient
 	InstanceName     string
+	MaxBatchBlobSize int64
+	StreamChunkSize  int64
 
 	// Map of a digest in string form to a bool representing whether it is known to be present or missing
 	// in the CAS.

--- a/pkg/load/action.go
+++ b/pkg/load/action.go
@@ -33,7 +33,7 @@ type ActionContext struct {
 	BytestreamClient bytestream_pb.ByteStreamClient
 	InstanceName     string
 	MaxBatchBlobSize int64
-	StreamChunkSize  int64
+	WriteChunkSize   int64
 
 	// Map of a digest in string form to a bool representing whether it is known to be present or missing
 	// in the CAS.

--- a/pkg/load/generate.go
+++ b/pkg/load/generate.go
@@ -24,8 +24,6 @@ import (
 
 	"github.com/toolchainlabs/remote-api-tools/pkg/casutil"
 	remote_pb "github.com/toolchainlabs/remote-api-tools/protos/build/bazel/remote/execution/v2"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 type generateAction struct {
@@ -64,6 +62,23 @@ func generateWorker(workChan <-chan *generateWorkItem, resultChan chan<- *genera
 	log.Debug("generateWorker stopped")
 }
 
+func writeBlobBatch(actionContext *ActionContext, data []byte) (*remote_pb.Digest, error) {
+	digest, err := casutil.PutBytes(actionContext.Ctx, actionContext.CasClient, data, actionContext.InstanceName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to write blob: %s", err)
+	}
+	return digest, nil
+}
+
+func writeBlobStream(actionContext *ActionContext, data []byte) (*remote_pb.Digest, error) {
+	digest, err := casutil.PutBytesStream(actionContext.Ctx, actionContext.BytestreamClient, data, actionContext.StreamChunkSize,
+		actionContext.InstanceName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to write blob (bytestream) %s", err)
+	}
+	return digest, nil
+}
+
 func processWorkItem(wi *generateWorkItem) *generateWorkResult {
 	buf := make([]byte, wi.blobSize)
 	n, err := rand.Read(buf)
@@ -79,28 +94,14 @@ func processWorkItem(wi *generateWorkItem) *generateWorkResult {
 			err: err,
 		}
 	}
-	digest := casutil.ComputeDigest(buf)
 
-	request := remote_pb.BatchUpdateBlobsRequest{
-		InstanceName: wi.actionContext.InstanceName,
-		Requests: []*remote_pb.BatchUpdateBlobsRequest_Request{
-			{
-				Digest: digest,
-				Data:   buf,
-			},
-		},
-	}
-
-	response, err := wi.actionContext.CasClient.BatchUpdateBlobs(wi.actionContext.Ctx, &request)
-	if err == nil {
-		s := status.FromProto(response.Responses[0].Status)
-		if s.Code() != codes.OK {
-			return &generateWorkResult{
-				blobSize: wi.blobSize,
-				err:      s.Err(),
-			}
-		}
+	var digest *remote_pb.Digest
+	if int64(wi.blobSize) < wi.actionContext.MaxBatchBlobSize {
+		digest, err = writeBlobBatch(wi.actionContext, buf)
 	} else {
+		digest, err = writeBlobStream(wi.actionContext, buf)
+	}
+	if err != nil {
 		return &generateWorkResult{
 			blobSize: wi.blobSize,
 			err:      err,

--- a/pkg/load/generate.go
+++ b/pkg/load/generate.go
@@ -71,7 +71,7 @@ func writeBlobBatch(actionContext *ActionContext, data []byte) (*remote_pb.Diges
 }
 
 func writeBlobStream(actionContext *ActionContext, data []byte) (*remote_pb.Digest, error) {
-	digest, err := casutil.PutBytesStream(actionContext.Ctx, actionContext.BytestreamClient, data, actionContext.StreamChunkSize,
+	digest, err := casutil.PutBytesStream(actionContext.Ctx, actionContext.BytestreamClient, data, actionContext.WriteChunkSize,
 		actionContext.InstanceName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to write blob (bytestream) %s", err)

--- a/pkg/load/read.go
+++ b/pkg/load/read.go
@@ -63,45 +63,62 @@ func readWorker(workChan <-chan *readWorkItem, resultChan chan<- *readWorkResult
 	log.Debug("readWorker stopped")
 }
 
-func processReadWorkItem(wi *readWorkItem) *readWorkResult {
-	// TODO: This should use bytestream if size execeeds the server's batch RPC limit.
-
+func readBlobBatch(actionContext *ActionContext, digest *remote_pb.Digest) ([]byte, error) {
 	request := remote_pb.BatchReadBlobsRequest{
-		InstanceName: wi.actionContext.InstanceName,
+		InstanceName: actionContext.InstanceName,
 		Digests: []*remote_pb.Digest{
-			wi.digest,
+			digest,
 		},
 	}
 
-	response, err := wi.actionContext.CasClient.BatchReadBlobs(wi.actionContext.Ctx, &request)
-	if err == nil {
-		s := status.FromProto(response.Responses[0].Status)
-		if s.Code() != codes.OK {
-			return &readWorkResult{
-				digest: wi.digest,
-				err:    s.Err(),
-			}
-		}
+	response, err := actionContext.CasClient.BatchReadBlobs(actionContext.Ctx, &request)
+	if err != nil {
+		return nil, err
+	}
 
-		data := response.Responses[0].Data
-		if int64(len(data)) != wi.digest.SizeBytes {
-			return &readWorkResult{
-				digest: wi.digest,
-				err:    fmt.Errorf("size mismatch, expected %d, actual %d", wi.digest.SizeBytes, len(data)),
-			}
-		}
+	s := status.FromProto(response.Responses[0].Status)
+	if s.Code() != codes.OK {
+		return nil, s.Err()
+	}
 
-		computedDigest := casutil.ComputeDigest(data)
-		if computedDigest.Hash != wi.digest.Hash {
-			return &readWorkResult{
-				digest: wi.digest,
-				err:    fmt.Errorf("digest hash mismatch"),
-			}
-		}
-	} else {
+	if len(response.Responses) != 1 {
+		return nil, fmt.Errorf("expected 1 response in RPC call, got %d responses instead", len(response.Responses))
+	}
+
+	digestResponse := response.Responses[0]
+
+	if digestResponse.Digest.Hash != digest.Hash {
+		return nil, fmt.Errorf("expected digest %s in RPC call, got digest %s instead", digest.Hash, digestResponse.Digest.Hash)
+	}
+
+	if digestResponse.Digest.SizeBytes != digest.SizeBytes {
+		return nil, fmt.Errorf("expected size %d in RPC call, got size %d instead", digest.SizeBytes, digestResponse.Digest.SizeBytes)
+	}
+
+	return response.Responses[0].Data, nil
+}
+
+func processReadWorkItem(wi *readWorkItem) *readWorkResult {
+	data, err := readBlobBatch(wi.actionContext, wi.digest)
+	if err != nil {
 		return &readWorkResult{
 			digest: wi.digest,
 			err:    err,
+		}
+	}
+
+	if int64(len(data)) != wi.digest.SizeBytes {
+		return &readWorkResult{
+			digest: wi.digest,
+			err:    fmt.Errorf("size mismatch, expected %d, actual %d", wi.digest.SizeBytes, len(data)),
+		}
+	}
+
+	computedDigest := casutil.ComputeDigest(data)
+	if computedDigest.Hash != wi.digest.Hash {
+		return &readWorkResult{
+			digest: wi.digest,
+			err:    fmt.Errorf("digest hash mismatch, expected %s, actual %s", wi.digest, computedDigest.Hash),
 		}
 	}
 


### PR DESCRIPTION
Teach `casload` to se the [ByteStream API](https://github.com/googleapis/googleapis/blob/master/google/bytestream/bytestream.proto) for large blobs.

`casload` now takes two additional options:

- `--max-batch-blob-size` sets the threshold for switching between the batch and ByteStream APIs
- `--write-chunk-size` sets the size of chunks written via the ByteStream API
