### PR TITLE
 Add Dockerfile w/ casload & smoketest tools

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -16,4 +16,3 @@ jobs:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
         tag_semver: true
- 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,19 @@
+name: Publish to DockerHub
+on:
+  push:
+    branches:
+      - main
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build & Publish nightly smoketest
+      uses: docker/build-push-action@v2
+      with:
+        build-args: APP_NAME=smoketest
+        name: toolchainlabs/remote-api-tools-smoketest:nighly
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+        tag_semver: true
+ 


### PR DESCRIPTION
Publish nightly build on every push.
we might want to do a on-release publish after we add versioning and do proper releases, but this will do for now.
Also, only smoketest tool for now, will add casload after making sure this flow wo