### PR TITLE
fix off by one error in stats display

### DIFF
--- a/pkg/stats/stats.go
+++ b/pkg/stats/stats.go
@@ -36,5 +36,5 @@ func PrintTimingStats(times []time.Duration) {
 		total,
 		average,
 		times[0],
-		times[len(times)])
+		times[len(times)-1])
 }


### PR DESCRIPTION
Fix an off-by-one error in displaying timing stats.