### PR TITLE
add initial set of targets to BUILD files

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,3 @@
+go_module(
+    name="root",
+)

--- a/cmd/casload/BUILD
+++ b/cmd/casload/BUILD
@@ -1,0 +1,1 @@
+go_package()

--- a/cmd/smoketest/BUILD
+++ b/cmd/smoketest/BUILD
@@ -1,0 +1,1 @@
+go_package()

--- a/pkg/casutil/BUILD
+++ b/pkg/casutil/BUILD
@@ -1,0 +1,1 @@
+go_package()

--- a/pkg/grpcutil/BUILD
+++ b/pkg/grpcutil/BUILD
@@ -1,0 +1,1 @@
+go_package()

--- a/pkg/load/BUILD
+++ b/pkg/load/BUILD
@@ -1,0 +1,1 @@
+go_package()

--- a/pkg/retry/BUILD
+++ b/pkg/retry/BUILD
@@ -1,0 +1,1 @@
+go_package()

--- a/pkg/stats/BUILD
+++ b/pkg/stats/BUILD
@@ -1,0 +1,1 @@
+go_package()

--- a/protos/build/bazel/remote/execution/v2/BUILD
+++ b/protos/build/bazel/remote/execution/v2/BUILD
@@ -1,0 +1,1 @@
+go_package()

--- a/protos/build/bazel/semver/BUILD
+++ b/protos/build/bazel/semver/BUILD
@@ -1,0 +1,1 @@
+go_package()


### PR DESCRIPTION
Use `./pants tailor` to produce the initial set of Go targets.