### PR TITLE
enable toolchain buildsense reporting

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -4,6 +4,9 @@ backend_packages.add = [
   "pants.backend.experimental.go",
   "pants.backend.experimental.go.lint.gofmt",
 ]
+plugins = [
+  "toolchain.pants.plugin==0.13.1",
+]
 
 [source]
 root_patterns = ["/"]
@@ -11,3 +14,9 @@ root_patterns = ["/"]
 [anonymous-telemetry]
 enabled = true
 repo_id = "E6C010FF-E41B-4AFE-9B6C-05F85B219046"
+
+[toolchain-setup]
+repo = "remote-api-tools"
+
+[buildsense]
+enable = true

--- a/pants_from_sources
+++ b/pants_from_sources
@@ -23,6 +23,7 @@ pythonpath=(
 )
 
 plugins=(
+  "toolchain.pants.plugin==0.13.1"
 )
 
 function string_list() {


### PR DESCRIPTION
Enable the `toolchain.pants.plugin` plugin to enable reporting of builds to Toolchain's Buildsense product. 
