### PR TITLE
update BUILD files for latest pants

### DIFF
--- a/cmd/casload/BUILD
+++ b/cmd/casload/BUILD
@@ -1,7 +1,4 @@
-go_package()
-
 go_binary(
   name="bin",
   output_path="casload",
-  main=":casload",
 )

--- a/cmd/smoketest/BUILD
+++ b/cmd/smoketest/BUILD
@@ -1,7 +1,4 @@
-go_package()
-
 go_binary(
   name="bin",
   output_path="smoketest",
-  main=":smoketest",
 )

--- a/pkg/casutil/BUILD
+++ b/pkg/casutil/BUILD
@@ -1,1 +1,0 @@
-go_package()

--- a/pkg/grpcutil/BUILD
+++ b/pkg/grpcutil/BUILD
@@ -1,1 +1,0 @@
-go_package()

--- a/pkg/load/BUILD
+++ b/pkg/load/BUILD
@@ -1,1 +1,0 @@
-go_package()

--- a/pkg/retry/BUILD
+++ b/pkg/retry/BUILD
@@ -1,1 +1,0 @@
-go_package()

--- a/pkg/stats/BUILD
+++ b/pkg/stats/BUILD
@@ -1,1 +1,0 @@
-go_package()

--- a/protos/build/bazel/remote/execution/v2/BUILD
+++ b/protos/build/bazel/remote/execution/v2/BUILD
@@ -1,1 +1,0 @@
-go_package()

--- a/protos/build/bazel/semver/BUILD
+++ b/protos/build/bazel/semver/BUILD
@@ -1,1 +1,0 @@
-go_package()


### PR DESCRIPTION
- `go_package` is no longer needed explicitly as `go_mod` will generate the necessary targets for first-party packages.
- The plugin will infer the main package to use for `go_binary` targets.