### PR TITLE
add CI job to run Pants

### DIFF
--- a/.github/workflows/pants.yaml
+++ b/.github/workflows/pants.yaml
@@ -1,0 +1,63 @@
+# Copyright 2022 Pants project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+# See https://pants.readme.io/docs/using-pants-in-ci for tips on how to set up your CI with Pants.
+
+name: Pants
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  org-check:
+    name: Check GitHub Organization
+    if: ${{ github.repository_owner == 'toolchainlabs' }}
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Noop
+        run: "true"
+  build:
+    name: Perform CI Checks
+    needs: org-check
+    env:
+      PANTS_CONFIG_FILES: pants.ci.toml
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7]
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/cache@v2
+      id: cache
+      with:
+        path: |
+          ~/.cache/pants/setup
+          ~/.cache/pants/lmdb_store
+          ~/.cache/pants/named_caches
+        key: ${{ runner.os }}-
+    - name: Setup Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Setup Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.17
+    - name: Bootstrap Pants
+      run: |
+        ./pants --version
+    - name: Check BUILD files
+      run: ./pants tailor --check update-build-files --check
+    - name: Lint
+      run: |
+        ./pants lint ::
+    #- name: Test
+    #  run: |
+    #    ./pants test ::
+    - name: Package
+      run: |
+        ./pants package ::
+

--- a/cmd/casload/BUILD
+++ b/cmd/casload/BUILD
@@ -1,6 +1,6 @@
 go_package()
 
 go_binary(
-  name="bin",
-  output_path="casload",
+    name="bin",
+    output_path="casload",
 )

--- a/cmd/smoketest/BUILD
+++ b/cmd/smoketest/BUILD
@@ -1,6 +1,6 @@
 go_package()
 
 go_binary(
-  name="bin",
-  output_path="smoketest",
+    name="bin",
+    output_path="smoketest",
 )

--- a/pants.ci.toml
+++ b/pants.ci.toml
@@ -1,0 +1,11 @@
+# Copyright 2022 Pants project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+# See https://www.pantsbuild.org/docs/using-pants-in-ci.
+
+[GLOBAL]
+dynamic_ui = false
+colors = true
+
+[pytest]
+args = ["-vv", "--no-header"]

--- a/pants.ci.toml
+++ b/pants.ci.toml
@@ -1,11 +1,5 @@
-# Copyright 2022 Pants project contributors.
-# Licensed under the Apache License, Version 2.0 (see LICENSE).
-
 # See https://www.pantsbuild.org/docs/using-pants-in-ci.
 
 [GLOBAL]
 dynamic_ui = false
 colors = true
-
-[pytest]
-args = ["-vv", "--no-header"]


### PR DESCRIPTION
Add a CI job to run Pants. This may not replace the `go` tool CI just yet, but good to run in parallel.