### PR TITLE
Use pants docker support to build smoketest and casload images

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,6 +38,10 @@ jobs:
       - name: Tests
         run: |
           ./pants test ::
+      - name: Build smoketest & casloader docker images
+        run: |
+          ./pants package cmd/::
+      # Keeping those here since the publish workflow wasn't ported to use pants.
       - name: Build smoketest docker image
         uses: docker/build-push-action@v3
         with:

--- a/cmd/casload/BUILD
+++ b/cmd/casload/BUILD
@@ -4,3 +4,13 @@ go_binary(
     name="bin",
     output_path="casload",
 )
+
+docker_image(
+    name="casload-docker",
+    dependencies=[":bin"],
+    instructions=[
+        "FROM alpine:3.13.2",
+        "COPY casload /usr/local/bin/",
+        'ENTRYPOINT ["/usr/local/bin/casload"]',
+    ],
+)

--- a/cmd/casload/BUILD
+++ b/cmd/casload/BUILD
@@ -1,4 +1,4 @@
-go_package()
+go_package(name="src")
 
 go_binary(
     name="bin",
@@ -6,7 +6,7 @@ go_binary(
 )
 
 docker_image(
-    name="casload-docker",
+    name="casload",
     dependencies=[":bin"],
     instructions=[
         "FROM alpine:3.13.2",

--- a/cmd/smoketest/BUILD
+++ b/cmd/smoketest/BUILD
@@ -1,11 +1,11 @@
-go_package()
+go_package(name="src")
 
 go_binary(
     name="bin",
     output_path="smoketest",
 )
 docker_image(
-    name="smoketest-docker",
+    name="smoketest",
     dependencies=[":bin"],
     instructions=[
         "FROM alpine:3.13.2",

--- a/cmd/smoketest/BUILD
+++ b/cmd/smoketest/BUILD
@@ -4,3 +4,12 @@ go_binary(
     name="bin",
     output_path="smoketest",
 )
+docker_image(
+    name="smoketest-docker",
+    dependencies=[":bin"],
+    instructions=[
+        "FROM alpine:3.13.2",
+        "COPY smoketest /usr/local/bin/",
+        'ENTRYPOINT ["/usr/local/bin/smoketest"]',
+    ],
+)

--- a/pants.toml
+++ b/pants.toml
@@ -3,6 +3,7 @@ pants_version = "2.14.0rc1"
 backend_packages.add = [
   "pants.backend.build_files.fmt.black",
   "pants.backend.experimental.go",
+  "pants.backend.docker",
 ]
 plugins = [
   "toolchain.pants.plugin==0.22.0",


### PR DESCRIPTION
I did this based on the docs https://www.pantsbuild.org/docs/docker and based on the example repo linked to from https://blog.pantsbuild.org/pants-pex-and-docker/  (which I found by googling `pantsbuild docker` it was the 2nd link in the search results)  
The reason I went to google is because from the docs, it wasn't obvious to me how to get a `go_binary` into the docker container.
There is no full, end 2 end example in the docs... it describes parts of the steps so the example repo helped me connect all the dots.

The example repo linked from the post was useful (I didn't read the blog post, as I was looking for the example)
https://github.com/StephanErb/pexample, specifically: https://github.com/StephanErb/pexample/tree/main/src/docker/math_fun/cli

Please provide feedback @Eric-Arellano @tdyas 
